### PR TITLE
feat(blog): subseções Podcast, Técnico e Pesquisas

### DIFF
--- a/archetypes/blogs.md
+++ b/archetypes/blogs.md
@@ -1,0 +1,11 @@
+---
+title: "{{ replace .File.ContentBaseName `-` ` ` | title }}"
+date: {{ .Date }}
+draft: true
+author: "Deive Leal"
+github_link: ""
+tags: []
+image: ""
+description: ""
+toc: true
+---

--- a/config.yaml
+++ b/config.yaml
@@ -24,33 +24,35 @@ markup:
 
 Menus:
   main:
+    # "Blog" é o item pai do dropdown (sem url = apenas abre o menu)
     - identifier: blog
       name: Blog
-      title: Blog posts
-      url: /blogs
+      title: Blog
       weight: 1
-    # - identifier: gallery
-    #   name: Gallery
-    #   title: Blog posts
-    #   url: /gallery
-    #   weight: 2
-    #Dropdown menu
-    # - identifier: dropdown
-    #   title: Example dropdown menu
-    #   name: Dropdown
-    #   weight: 3
-    # - identifier: dropdown1
-    #   title: example dropdown 1
-    #   name: example 1
-    #   url: /#
-    #   parent: dropdown
-    #   weight: 1
-    # - identifier: dropdown2
-    #   title: example dropdown 2
-    #   name: example 2
-    #   url: /#
-    #   parent: dropdown
-    #   weight: 2
+    - identifier: blog-all
+      name: Todos os posts
+      title: Todos os posts
+      url: /blogs
+      parent: blog
+      weight: 1
+    - identifier: blog-podcast
+      name: Podcast
+      title: Podcast
+      url: /blogs/podcast
+      parent: blog
+      weight: 2
+    - identifier: blog-tecnico
+      name: Técnico
+      title: Técnico
+      url: /blogs/tecnico
+      parent: blog
+      weight: 3
+    - identifier: blog-pesquisas
+      name: Pesquisas
+      title: Pesquisas
+      url: /blogs/pesquisas
+      parent: blog
+      weight: 4
 
 params:
   title: "Deive Leal"

--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,8 @@ outputs:
     - "HTML"
     - "RSS"
 
-pagination.pagerSize: 3
+pagination:
+  pagerSize: 3
 enableRobotsTXT: true
 # disqusShortname: your-disqus-shortname
 # googleAnalytics: G-MEASUREMENT_ID

--- a/content/blogs/_index.md
+++ b/content/blogs/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Blog"
+description: "Textos sobre podcast, temas técnicos e pesquisas."
+---

--- a/content/blogs/pesquisas/_index.md
+++ b/content/blogs/pesquisas/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Pesquisas"
+description: "Estudos, levantamentos e pesquisas aprofundadas."
+---

--- a/content/blogs/pesquisas/exemplo-pesquisa.md
+++ b/content/blogs/pesquisas/exemplo-pesquisa.md
@@ -1,0 +1,27 @@
+---
+title: "Exemplo: Pesquisa"
+date: 2026-07-21T12:00:00-03:00
+draft: true
+author: "Deive Leal"
+github_link: ""
+tags:
+  - Pesquisa
+image: ""
+description: "Modelo de post de pesquisa — duplique este arquivo e troque o conteúdo."
+toc: true
+---
+
+> Post-modelo (`draft: true`), não publica. Rode
+> `hugo new blogs/pesquisas/minha-pesquisa.md` para criar um novo.
+
+## Objetivo
+
+O que a pesquisa investiga.
+
+## Metodologia
+
+Fontes, dados e método.
+
+## Resultados
+
+Achados e referências.

--- a/content/blogs/podcast/_index.md
+++ b/content/blogs/podcast/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Podcast"
+description: "Transcrições, notas e textos derivados de episódios de podcast."
+---

--- a/content/blogs/podcast/exemplo-episodio.md
+++ b/content/blogs/podcast/exemplo-episodio.md
@@ -1,0 +1,23 @@
+---
+title: "Exemplo: Notas do Episódio 01"
+date: 2026-07-21T12:00:00-03:00
+draft: true
+author: "Deive Leal"
+github_link: ""
+tags:
+  - Podcast
+image: ""
+description: "Modelo de post de podcast — duplique este arquivo e troque o conteúdo."
+toc: true
+---
+
+> Este é um post-modelo (`draft: true`), não aparece em produção. Copie-o para
+> criar um novo, ou rode `hugo new blogs/podcast/meu-episodio.md`.
+
+## Resumo do episódio
+
+Escreva aqui o resumo, os principais pontos e os links citados.
+
+## Transcrição / notas
+
+Cole aqui a transcrição ou suas anotações.

--- a/content/blogs/tecnico/Common-Table-Expression-or-Just-CTE.md
+++ b/content/blogs/tecnico/Common-Table-Expression-or-Just-CTE.md
@@ -13,6 +13,8 @@ tags:
 image: /images/projects/cte/gatos_cte.png
 description: ""
 toc: 
+aliases:
+  - /blogs/common-table-expression-or-just-cte/
 ---
 
 When I started my studies in sql to handle data from databases many things seemed confused and messed up. The use of nested queries or subqueries was kind of confusing. The longer the query is more difficult, it is to understand what it does. Consequently, its reading, debugging and maintenance are equally difficult. For instance, imagine a code with seven or more different subqueries. The limit is your imagination. But, the more subqueries you have, more business rules can be applied and, consequently, the challenge to maintain them increases. To help us with this great problem, a good option is to use common table expressions or aka cte.

--- a/content/blogs/tecnico/_index.md
+++ b/content/blogs/tecnico/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Técnico"
+description: "Artigos técnicos: dados, SQL, engenharia de software e afins."
+---

--- a/content/blogs/tecnico/exemplo-artigo-tecnico.md
+++ b/content/blogs/tecnico/exemplo-artigo-tecnico.md
@@ -1,0 +1,31 @@
+---
+title: "Exemplo: Artigo Técnico"
+date: 2026-07-21T12:00:00-03:00
+draft: true
+author: "Deive Leal"
+github_link: ""
+tags:
+  - Técnico
+image: ""
+description: "Modelo de artigo técnico — duplique este arquivo e troque o conteúdo."
+toc: true
+---
+
+> Post-modelo (`draft: true`), não publica. Rode
+> `hugo new blogs/tecnico/meu-artigo.md` para criar um novo.
+
+## Contexto
+
+Descreva o problema e o cenário.
+
+## Solução
+
+Explique a abordagem, com blocos de código quando necessário:
+
+```sql
+SELECT 1;
+```
+
+## Conclusão
+
+Fechamento e próximos passos.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,56 @@
+{{ define "head" }}
+<meta name="description" content="{{ .Title }} of {{ .Site.Title }}">
+<link rel="stylesheet" href="{{ .Site.Params.staticPath }}/css/list.css" media="all">
+{{ end }}
+
+{{ define "title" }}
+{{.Title }} | {{ .Site.Title }}
+{{ end }}
+
+{{ define "main" }}
+{{/* Override de projeto: na página principal do blog (/blogs) listamos os posts
+     de forma recursiva (raiz + subseções: podcast, técnico, pesquisas).
+     Nas demais listas (subseções, taxonomias) mantemos o comportamento padrão. */}}
+{{ $pageSet := .Pages }}
+{{ if eq .RelPermalink "/blogs/" }}
+  {{ $pageSet = .RegularPagesRecursive }}
+{{ end }}
+{{ $paginator := .Paginate $pageSet }}
+<div class="container pt-5" id="list-page">
+    <h2 class="text-center pb-2">{{.Title}}</h2>
+    <div class="row">
+        {{ range $paginator.Pages }}
+        <div class="col-lg-4 col-md-6 my-3">
+            <div class="card-columns">
+                <div class="card h-100">
+                    {{ if and (not (.Site.Params.listPages.disableFeaturedImage | default false)) (.Params.image) }}
+                    <div class="card-header">
+                        <a href="{{ .RelPermalink }}">
+                            <img src="{{ .Params.image }}" class="card-img-top" alt="{{ .Title }}">
+                        </a>
+                    </div>
+                    {{ end }}
+                    <div class="card-body bg-transparent p-4 shadow-sm">
+                        <a href="{{ .RelPermalink }}" class="primary-font card-title">
+                            <h5 class="card-title bg-transparent" title="{{ .Title }}">{{ .Title | truncate 25 }}</h5>
+                        </a>
+                        <div class="card-text secondary-font">
+                            <p>{{ .Summary | truncate 300}}</p>
+                        </div>
+                    </div>
+                    <div class="mt-auto post-footer bg-transparent py-3">
+                        <span class="float-start bg-transparent">{{ .Date.Format (.Site.Params.datesFormat.articleList | default "January 2, 2006") }}</span>
+                        <a href="{{ .RelPermalink }}" class="float-end btn btn-outline-info btn-sm">{{ .Site.Params.terms.read | default "Read" }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {{ end }}
+        <div class="row justify-content-center">
+            <div class="col-auto m-3">
+                {{ template "_internal/pagination.html" . }}
+            </div>
+        </div>
+    </div>
+</div>
+{{ end }}


### PR DESCRIPTION
## O que muda

Adiciona ao blog subseções por tipo de conteúdo: **Podcast**, **Técnico** e **Pesquisas**.

### Estrutura
```
content/blogs/
├── _index.md              → landing do blog
├── podcast/_index.md      → /blogs/podcast/
├── tecnico/_index.md      → /blogs/tecnico/
├── pesquisas/_index.md    → /blogs/pesquisas/
└── (+ 1 post-modelo draft por subseção)
```

### Navegação
O item **Blog** vira um dropdown: `Todos os posts` · `Podcast` · `Técnico` · `Pesquisas`.

### Feed recursivo
Override de projeto em `layouts/_default/list.html`: a página `/blogs` lista **todos** os posts recursivamente (raiz + subseções), enquanto cada subseção mostra apenas os seus. Taxonomias e demais listas mantêm o comportamento padrão do tema.

### Scaffolding
`archetypes/blogs.md` com o front matter do tema, permitindo:
```bash
hugo new blogs/podcast/episodio-01.md
```

### Conteúdo existente
O post **CTE** foi movido para `blogs/tecnico/`, com `aliases` preservando a URL antiga (`/blogs/common-table-expression-or-just-cte/` → redirect), sem quebrar links nem sitemap. O post *About Entrepreneurship* permanece na raiz.

## Validação
- `hugo --gc` (produção): **48 páginas, 0 erros/warnings**, 19 aliases.
- Com `--buildDrafts`: posts publicados aparecem na subseção **e** no feed `/blogs`; cada subseção isola os seus.
- `hugo new blogs/<sub>/<post>.md` gera o front matter correto.

## Notas
- Os posts-modelo são `draft: true` (não publicam) — servem de gabarito; podem ser removidos.
- Config git local: `submodule.themes/hugo-profile.ignore = dirty` (evita lentidão do git pela sujeira cosmética de EOL do submódulo; não afeta versionamento nem a CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
