### PR TITLE
ci: valida PRs com build do Hugo (sem deploy)

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["main"]
 
+  # Valida (build sem deploy) os PRs que miram a branch default
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -18,7 +22,9 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  # Deploys da main são serializados (mesmo grupo); cada PR tem seu próprio
+  # grupo, então validações de PR não bloqueiam o deploy de produção.
+  group: "pages-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: false
 
 # Default to bash
@@ -27,8 +33,9 @@ defaults:
     shell: bash
 
 jobs:
-  # Build job
+  # Build + deploy job (apenas em push na main / execução manual — nunca em PR)
   build:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.124.1
@@ -73,3 +80,27 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Validation job — roda apenas em pull_request: builda o site para validar
+  # o PR antes do merge, sem publicar nada.
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.124.1
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build with Hugo (validação, sem deploy)
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: hugo --minify


### PR DESCRIPTION
## O que muda

Adiciona validação automática de **Pull Requests**: todo PR que mira a `main` passa a rodar um build do Hugo (sem deploy), pegando erros antes do merge.

### Detalhes
- Novo gatilho `pull_request` (branches: `main`).
- Novo job **`validate`** (só em PR): instala Hugo/Dart Sass, faz checkout com submódulos e roda `hugo --minify`. **Não publica nada.**
- Job **`build`/`deploy`** agora só roda em `push`/execução manual (`if: github.event_name != 'pull_request'`), evitando deploy acidental a partir de um PR.
- **Concurrency por-PR** (`pages-<pr>|<ref>`): validações de PR não bloqueiam mais o deploy de produção; deploys da `main` seguem serializados.

### Por que
Hoje o workflow só dispara em `push` na `main` — um erro de build só apareceria **depois** do merge, no deploy. Este PR fecha essa lacuna.

## Auto-teste
Como este próprio PR mira a `main` e já contém o gatilho, o job `validate` roda aqui — se o check passar, a validação está funcionando end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
